### PR TITLE
Fix homepage with not ul tag throwing exception

### DIFF
--- a/src/Documentation.php
+++ b/src/Documentation.php
@@ -65,7 +65,7 @@ class Documentation
                 $homepage = \config('wisteria.docs.index', \config('wisteria.docs.home', 'README.md'));
 
                 if ($this->has($version, $homepage)) {
-                    return $this->replaceLinks($version, (new Crawler($this->get($version, $homepage)))->filter('ul')->html());
+                    return $this->replaceLinks($version, (new Crawler($this->get($version, $homepage)))->filter('ul')->html(''));
                 }
 
                 return null;


### PR DESCRIPTION
## 问题
当 `$homepage` 文件中没有 `ul`标签时，`Crawler` 的 `html` 方法会抛出 `The current node list is empty.` 异常。

## 解决方法

只需要给 `html` 方法传递一个默认值即可。

## 测试

```
$crawler = new Crawler('mock-content');

$this->assertEmpty($crawler->filter('ul')->html(''));

$this->expectException(\InvalidArgumentException::class);
$this->expectExceptionMessage('The current node list is empty.');

$crawler->filter('ul')->html();
```